### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Force Fetch Git Tags
       run: git fetch --tags --force
     - name: Set SHORT_HASH
-      run: echo "::set-output name=VALUE::${LONG_HASH:0:8}"
+      run: echo "VALUE=${LONG_HASH:0:8}" >> $GITHUB_OUTPUT
       id: short_hash
       env:
         LONG_HASH: ${{ github.sha }}

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Force Fetch Git Tags
       run: git fetch --tags --force
     - name: Set SHORT_HASH
-      run: echo "::set-output name=VALUE::${LONG_HASH:0:8}"
+      run: echo "VALUE=${LONG_HASH:0:8}" >> $GITHUB_OUTPUT
       id: short_hash
       env:
         LONG_HASH: ${{ github.sha }}

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Force Fetch Git Tags
       run: git fetch --tags --force
     - name: Set SHORT_HASH
-      run: echo "::set-output name=VALUE::${LONG_HASH:0:8}"
+      run: echo "VALUE=${LONG_HASH:0:8}" >> $GITHUB_OUTPUT
       id: short_hash
       env:
         LONG_HASH: ${{ github.sha }}

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -47,7 +47,7 @@ jobs:
         tar xf qt-5.15.2.arm64_big_sur.bottle.tar.gz
         python3 .github/CI_MISC/pre_qt_universal_build.py $Qt5_DIR/ `pwd`/qt@5/5.15.2/
     - name: Set SHORT_HASH
-      run: echo "::set-output name=VALUE::${LONG_HASH:0:8}"
+      run: echo "VALUE=${LONG_HASH:0:8}" >> $GITHUB_OUTPUT
       id: short_hash
       env:
         LONG_HASH: ${{ github.sha }}

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Set SHORT_HASH
       run: |
         $short_hash = "${{ env.LONG_HASH }}".substring(0, 8)
-        echo "::set-output name=VALUE::$short_hash"
+        echo "VALUE=$short_hash" >> $GITHUB_OUTPUT
       id: short_hash
       env:
         LONG_HASH: ${{ github.sha }}

--- a/.github/workflows/build-windows_psf.yaml
+++ b/.github/workflows/build-windows_psf.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Set SHORT_HASH
       run: |
         $short_hash = "${{ env.LONG_HASH }}".substring(0, 8)
-        echo "::set-output name=VALUE::$short_hash"
+        echo "VALUE=$short_hash" >> $GITHUB_OUTPUT
       id: short_hash
       env:
         LONG_HASH: ${{ github.sha }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


